### PR TITLE
added solr base filter to islandora_exhibits_browse_build_results()

### DIFF
--- a/islandora_exhibits_browse.module
+++ b/islandora_exhibits_browse.module
@@ -298,6 +298,7 @@ function islandora_exhibits_browse_build_results($solr, $pid) {
   $fl_params = "PID, dc.title, dc.description, dc.date, mods_originInfo_dateCreated_ms";
 //  $solr_build->solrParams['fl'] = array($fl_params);
   $solr_build->solrParams['fl'] = '';
+  $solr_build->solrParams['fq'] = variable_get('islandora_solr_base_filter', '');
 
   // This section resets the limits on the query and re-executes.
   $solr_build->solrStart = 0;
@@ -342,4 +343,3 @@ function islandora_exhibits_browse_pager_timeline($result_fields = array()) {
     'total' => $total,
   );
 }
-


### PR DESCRIPTION
This will add the solr base filter to the underlying solr query in islandora_exhibits_browse_build_results().

After installing, to test this feature - simply add a filter to the Solr configuration that would filter the objects in an existing exhibit view.
1. view any existing exhibit page and take note of the total number of objects that appear.
2. from /admin/islandora/search/islandora_solr/settings in the Query Defaults section, add a valid solr filter such as `dc.description:*m*` (that should reduce the objects when applied to a solr query)
3. refresh the same exhibit page and confirm that the solr filter is applied by noting that all of the results have the filter logic applied to them (ie: each dc.description would contain the letter "m" for the filter example from 2.)

After this pull request is approved and merged, you may close https://github.com/simonhm/islandora_exhibits_browse/issues/2.